### PR TITLE
Update install.sh for Apple Silicon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@ cd $BASEDIR
 
 set -ex
 
-sudo cp -R U.S.-Czech.bundle/ /Library/Keyboard\ Layouts/U.S.-Czech.bundle/
-sudo touch /Library/Keyboard\ Layouts
+sudo cp -R U.S.-Czech.bundle/ ~/Library/Keyboard\ Layouts/U.S.-Czech.bundle/
+sudo touch ~/Library/Keyboard\ Layouts
 
 { set +x; } 2>/dev/null
 


### PR DESCRIPTION
Not sure if it's a Apple Silicon thing or a new macOS thing. But I got a new MBP last week and installed your amazing keyboard but unlike on my old MBP, it did not work. It did not add the keyboard to the Input Sources in System Preferences > Keyboard > Input Sources

I looked into it and that was the necessary change. 

Reference: https://superuser.com/questions/1788673/custom-keyboard-layout-folder-not-updating-in-mac-monterey#comment2797599_1788673

I tested the script locally and it works.

Thank you for making such a handy tool! 🙏🏽